### PR TITLE
fix: added iron-resize handles, and added check for window width chan…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "polymer": "^1.5.0",
+    "iron-resizable-behavior": "~1.0.3",
     "px-theme": "https://github.com/PredixDev/px-theme.git#~0.8.0",
     "px": "https://github.com/PredixDev/px.git#1.4.2"
   },

--- a/px-simple-chart-common-behavior.html
+++ b/px-simple-chart-common-behavior.html
@@ -1,3 +1,4 @@
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <script type="text/javascript" src="../px/dist/px.min.js"></script>
 <script>
 /*
@@ -29,7 +30,8 @@
 
 */
 
-window.pxSimpleChartCommonBehavior = {
+
+var _pxSimpleChartCommonBehavior = {
 
     /**
     * Private Properties
@@ -67,10 +69,27 @@ window.pxSimpleChartCommonBehavior = {
             type: String,
             observer: '_drawChart',
             value: this.defaultHeight
+        },
+        /**
+        * The time to debounce all re-draws
+        *
+        * @prop debounceTime
+        */
+        debounceTime: {
+          type: Number,
+          value: 50
         }
 
     },
 
+    /**
+     * Store the window width for re-draw.
+     * @private
+     */
+    _windowWidth: null,
+    created: function(){
+      this._windowWidth = window.innerWidth;
+    },
     /**
      * @method attached
      * Polymer fires this event automatically, we use it to define
@@ -78,8 +97,23 @@ window.pxSimpleChartCommonBehavior = {
      *
     */
     attached: function() {
-        this.svg = d3.select(this.$$("svg"));
-        this._drawChart();
+      this.svg = d3.select(this.$$("svg"));
+      this._drawChart();
+      this.listen(this, 'iron-resize', '_shouldDrawChart');
+    },
+    /**
+     * @method _shouldDrawChart
+     * Checks to see if the browsers width has changed before drawing chart.
+     * This fixes issue on mobile devices where chart re-draws happen continiously.
+     */
+
+    _shouldDrawChart: function(){
+      this.debounce('_shouldDrawChart', function(){
+        if(this._windowWidth !== window.innerWidth){
+          //console.warn(this._windowWidth, 'Window width did change, drawing chart.');
+          this._drawChart();
+        }
+      });
     },
 
     /**
@@ -87,12 +121,13 @@ window.pxSimpleChartCommonBehavior = {
      * removes previous chart, draws new chart. Debounced.
     */
     _drawChart: function() {
+      this._windowWidth = window.innerWidth;
         if(this.svg) {
             this._removeChart();
             // multiple calls to _drawChart need to be debounced
             this.debounce('_drawChartDebounced', function() {
                 this._drawChartDebounced();
-            }, 310);
+            }, this.debounceTime);
         }
     },
 
@@ -104,7 +139,7 @@ window.pxSimpleChartCommonBehavior = {
         this.debounce('_removeChartDebounced', function() {
             // first ensure that our SVG element is empty
             this._removeChartDebounced();
-        }, 300);
+        });
     },
 
     /**
@@ -436,10 +471,14 @@ window.pxSimpleChartCommonBehavior = {
         // if auto-resize is necessary, set window.onresize listener
         if(this.height === 'auto' || this.width === 'auto') {
             var that = this;
+            /*
             window.addEventListener('resize', function() {
+              console.log('Drawing chart');
                 that._drawChart();
             });
+            */
         }
     }
 };
+window.pxSimpleChartCommonBehavior = [Polymer.IronResizableBehavior, _pxSimpleChartCommonBehavior];
 </script>


### PR DESCRIPTION
# Pull Request
- Added iron-resize behavior and removed window.addEventListener('scroll')
- At created the browsers width is stored in a private var, the chart is always rendered first. Then when the iron-resize event fires, we check the current window width, and if its changed, we redraw.
- iOS scroll redraw issue - https://github.com/PredixDev/px-simple-chart-common-behavior/issues/1

@mdwragg 

N/A this cannot be tested as how would you reproduce a scroll on iOS device.
